### PR TITLE
Add regression tests for MQTT payload size handling

### DIFF
--- a/test/producer3.osql
+++ b/test/producer3.osql
@@ -1,0 +1,25 @@
+load_osql("mqtt.osql");
+
+set :mqtt_connect_opts = {
+  "qos": 1,
+  "connection": "tcp://localhost:1883",
+  "clientid": "producer3-qos1"
+};
+
+
+mqtt:register_client("mqtt",:mqtt_connect_opts);
+
+
+sink((select pivot_streams([s1,s2,s3,s4,s5,s6,s7])
+  from Stream s1, Stream s2, Stream s3 , Stream s4, Stream s5, Stream s6, Stream s7
+ where s1 = publish(sample_stream(zeros(1), 1),"mqtt:test_payloads/single_zeros_array", { "keep-alive": true })
+   and s2 = publish(sample_stream(zeros(2), 1),"mqtt:test_payloads/double_zeros_array", { "keep-alive": true })
+   and s3 = publish(sample_stream(zeros(126), 1),"mqtt:test_payloads/below_utf8_offset_table_step_size_zero_array", { "keep-alive": true })
+   and s4 = publish(sample_stream(zeros(127), 1),"mqtt:test_payloads/utf8_offset_table_step_size_zero_array", { "keep-alive": true })
+   and s5 = publish(sample_stream(zeros(128), 1),"mqtt:test_payloads/above_utf8_offset_table_step_size_zero_array", { "keep-alive": true })
+   and s6 = publish(sample_stream(zeros(10000), 1),"mqtt:test_payloads/10k_zeros_array", { "keep-alive": true })
+   and s7 = publish(sample_stream("Testing raw string payload", 1),"mqtt:test_payloads/raw_string", { "keep-alive": true })));
+
+quit;
+
+

--- a/test/setup_test.lsp
+++ b/test/setup_test.lsp
@@ -1,8 +1,9 @@
 (defun start-producer(args)
   "Start sa.engine MQTT-producer"
   (cond ((memq (os) '(linux osx))
-         (start-program (concat "sa.engine " args  " > /dev/null")))
+         (start-program (concat "sa.engine " args)))
         (t (start-program (concat "sa.engine " args)))))
 
-(start-producer "-O test/producer1.osql")
-(start-producer "-O test/producer2.osql")
+(start-producer "-O test/producer1.osql > /dev/null")
+(start-producer "-O test/producer2.osql > /dev/null")
+(start-producer "-O test/producer3.osql > /dev/null")

--- a/test/test.osql
+++ b/test/test.osql
@@ -72,4 +72,41 @@ validate "MQTT Modify and relay"
               where b in subscribe("mqtt:/modified"))))) 
           limit 10 => bag(12,13,14,10,11);
 
+validate "String payload not crashing"
+  check first(timeout(
+    (select stream of charstring(b) from binary b where b in subscribe("mqtt1:test_payloads/raw_string"))
+    , 5)) => "Testing raw string payload";
+
+validate "Payload size: 1-element zeros array"
+  check first(timeout(
+    (select stream of dim(b) from binary b where b in subscribe("mqtt1:test_payloads/single_zeros_array"))
+    , 5)) => 3; // [0]
+
+validate "Payload size: 2-element zeros array"
+  check first(timeout(
+    (select stream of dim(b) from binary b where b in subscribe("mqtt1:test_payloads/double_zeros_array"))
+    , 5)) => 5; // [0,0]
+
+validate "Payload size: below utf8 offset table step size"
+  check first(timeout(
+    (select stream of dim(b) from binary b where b in subscribe("mqtt1:test_payloads/below_utf8_offset_table_step_size_zero_array"))
+    , 5)) => 253; // [0,...0] - 126 0s
+
+
+validate "Payload size: at utf8 offset table step size"
+  check first(timeout(
+    (select stream of dim(b) from binary b where b in subscribe("mqtt1:test_payloads/utf8_offset_table_step_size_zero_array"))
+    , 5)) => 255; // [0,...0] - 127 0s
+
+
+validate "Payload size: above utf8 offset table step size"
+  check first(timeout(
+    (select stream of dim(b) from binary b where b in subscribe("mqtt1:test_payloads/above_utf8_offset_table_step_size_zero_array"))
+    , 5)) => 257; // [0,...0] - 128 0s
+
+validate "Payload length: 10k element zeros array"
+  check first(timeout(
+    (select stream of dim(b) from binary b where b in subscribe("mqtt1:test_payloads/10k_zeros_array"))
+    , 5)) => 20001; // [0,...0] - 10k 0s
+
 quit;


### PR DESCRIPTION
## Summary

Adds regression tests for the MQTT payload size bug fixed in `main` (corrected payload length calculation in `mqtt_publishfn`).

## Changes

- **test/producer3.osql** (new) — New MQTT producer publishing 7 test streams covering payload size edge cases: single-element arrays, arrays at/around the UTF-8 offset table step size boundary (126, 127, 128 elements), a large 10k-element array, and a raw string payload.
- **test/test.osql** — 7 new `validate` test cases that subscribe to the producer3 topics and assert correct byte lengths for each payload size, plus a string payload round-trip check.
- **test/setup_test.lsp** — Starts the new `producer3.osql` alongside existing producers. Minor fix: moves `> /dev/null` redirect into the argument string so it applies correctly.

## Key boundary values tested

1, 2, 126, 127, 128, and 10,000 element zero-arrays — specifically targeting the UTF-8 offset table step size boundary (127/128) where the original payload length miscalculation occurred.
